### PR TITLE
Form Lexicon

### DIFF
--- a/community/lexicon/forms/answer.json
+++ b/community/lexicon/forms/answer.json
@@ -1,0 +1,33 @@
+{
+  "lexicon": 1,
+  "id": "community.lexicon.forms.answer",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record declaring an answer to a question in a form.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": [
+          "subject",
+          "values"
+        ],
+        "properties": {
+          "subject": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "The question this answer is to."
+          },
+          "values": {
+            "type": "array",
+            "description": "The values of the response. For text or multiple choiced based question, length will be one.",
+            "items": {
+              "type": "string",
+              "maxLength": 5000
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/community/lexicon/forms/form.json
+++ b/community/lexicon/forms/form.json
@@ -31,10 +31,10 @@
           },
           "questions": {
             "type": "array",
-            "description": "The locations where the event takes place.",
+            "description": "The questions in the form.",
             "items": {
               "type": "ref",
-              "ref": "community.lexicon.forms.question"
+              "ref": "com.atproto.repo.strongRef"
             }
           }
         }

--- a/community/lexicon/forms/form.json
+++ b/community/lexicon/forms/form.json
@@ -1,0 +1,38 @@
+{
+    "lexicon": 1,
+    "id": "community.lexicon.forms.form",
+    "defs": {
+        "main": {
+            "type": "record",
+            "description": "Record declaring an form with questions.",
+            "key": "tid",
+            "record": {
+                "type": "object",
+                "required": [
+                    "title",
+                    "questions"
+                ],
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "maxLength": 100,
+                        "description": "The title of the form."
+                    },
+                    "description": {
+                        "type": "string",
+                        "maxLength": 2000,
+                        "description": "Description of the form."
+                    },
+                    "questions": {
+                        "type": "array",
+                        "description": "The locations where the event takes place.",
+                        "items": {
+                            "type": "ref",
+                            "ref": "community.lexicon.forms.question"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/community/lexicon/forms/form.json
+++ b/community/lexicon/forms/form.json
@@ -10,6 +10,7 @@
         "type": "object",
         "required": [
           "title",
+          "createdAt",
           "questions"
         ],
         "properties": {
@@ -17,6 +18,11 @@
             "type": "string",
             "maxLength": 100,
             "description": "The title of the form."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when this event was originally created."
           },
           "description": {
             "type": "string",

--- a/community/lexicon/forms/form.json
+++ b/community/lexicon/forms/form.json
@@ -1,38 +1,38 @@
 {
-    "lexicon": 1,
-    "id": "community.lexicon.forms.form",
-    "defs": {
-        "main": {
-            "type": "record",
-            "description": "Record declaring an form with questions.",
-            "key": "tid",
-            "record": {
-                "type": "object",
-                "required": [
-                    "title",
-                    "questions"
-                ],
-                "properties": {
-                    "title": {
-                        "type": "string",
-                        "maxLength": 100,
-                        "description": "The title of the form."
-                    },
-                    "description": {
-                        "type": "string",
-                        "maxLength": 2000,
-                        "description": "Description of the form."
-                    },
-                    "questions": {
-                        "type": "array",
-                        "description": "The locations where the event takes place.",
-                        "items": {
-                            "type": "ref",
-                            "ref": "community.lexicon.forms.question"
-                        }
-                    }
-                }
+  "lexicon": 1,
+  "id": "community.lexicon.forms.form",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record declaring an form with questions.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": [
+          "title",
+          "questions"
+        ],
+        "properties": {
+          "title": {
+            "type": "string",
+            "maxLength": 100,
+            "description": "The title of the form."
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 2000,
+            "description": "Description of the form."
+          },
+          "questions": {
+            "type": "array",
+            "description": "The locations where the event takes place.",
+            "items": {
+              "type": "ref",
+              "ref": "community.lexicon.forms.question"
             }
+          }
         }
+      }
     }
+  }
 }

--- a/community/lexicon/forms/question.json
+++ b/community/lexicon/forms/question.json
@@ -35,6 +35,11 @@
               "type": "ref",
               "ref": "community.lexicon.forms.question#questionoption"
             }
+          },
+          "required": {
+            "type": "boolean",
+            "description": "Indicates if this question must be answered.",
+            "default": false
           }
         }
       }
@@ -60,9 +65,9 @@
           "type": "string",
           "description": "The text of the option."
         },
-        "image": {
+        "media": {
             "type": "blob",
-            "description": "Optional: A URL to an image representing the option.",
+            "description": "Optional: A URL to an image representing or complimenting the option.",
             "accept": ["image/png", "image/jpeg"],
             "maxSize": 1000000
           }

--- a/community/lexicon/forms/question.json
+++ b/community/lexicon/forms/question.json
@@ -1,0 +1,84 @@
+{
+  "lexicon": 1,
+  "id": "community.lexicon.forms.question",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record declaring a question in a form.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": [
+          "title",
+          "questiontype"
+        ],
+        "properties": {
+          "title": {
+            "type": "string",
+            "maxLength": 100,
+            "description": "The title of the question."
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 2000,
+            "description": "Description of the question."
+          },
+          "questiontype": {
+            "type": "ref",
+            "ref": "community.lexicon.forms.question#questiontype",
+            "description": "The type of question."
+          },
+          "questionoptions": {
+            "type": "array",
+            "description": "The options for a question with multiple answers.",
+            "items": {
+              "type": "ref",
+              "ref": "community.lexicon.forms.question#questionoption"
+            }
+          }
+        }
+      }
+    },
+    "questiontype": {
+      "type": "string",
+      "description": "The type the question.",
+      "default": "community.lexicon.forms.question#text",
+      "knownValues": [
+        "community.lexicon.forms.question#text",
+        "community.lexicon.forms.question#multiplechoice",
+        "community.lexicon.calendar.event#selectmany"
+      ]
+    },
+    "questionoption": {
+      "type": "object",
+      "description": "A single option for a multiple-choice question.",
+      "required": [
+          "text"
+      ],
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "The text of the option."
+        },
+        "image": {
+            "type": "blob",
+            "description": "Optional: A URL to an image representing the option.",
+            "accept": ["image/png", "image/jpeg"],
+            "maxSize": 1000000
+          }
+      }
+    },
+    "text": {
+      "type": "token",
+      "description": "A text based question."
+    },
+    "multiplechoice": {
+      "type": "token",
+      "description": "A multiple choice based question."
+    },
+    "selectmany": {
+      "type": "token",
+      "description": "A multiple selection based question."
+    }
+  }
+}

--- a/community/lexicon/forms/response.json
+++ b/community/lexicon/forms/response.json
@@ -10,44 +10,27 @@
         "type": "object",
         "required": [
           "subject",
+          "createdAt",
           "answers"
         ],
         "properties": {
           "subject": {
             "type": "ref",
-            "ref": "community.lexicon.forms.form#main",
+            "ref": "com.atproto.repo.strongRef",
             "description": "The form the response is to."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when this event was originally created."
           },
           "answers": {
             "type": "array",
             "description": "The answers to the questions in the form.",
             "items": {
               "type": "ref",
-              "ref": "community.lexicon.forms.response#questionanswer"
+              "ref": "community.lexicon.forms.answer.defs#main"
             }
-          }
-        }
-      }
-    },
-    "questionanswer": {
-      "type": "object",
-      "description": "An answer to a specific question in a form.",
-      "required": [
-          "subject",
-          "values"
-      ],
-      "properties": {
-        "subject": {
-          "type": "ref",
-          "ref": "community.lexicon.forms.question#main",
-          "description": "The question this answer is to."
-        },
-        "values": {
-          "type": "array",
-          "description": "The values of the response. For text or multiple choiced based question, length will be one.",
-          "items": {
-            "type": "string",
-            "maxLength": 5000
           }
         }
       }

--- a/community/lexicon/forms/response.json
+++ b/community/lexicon/forms/response.json
@@ -1,0 +1,56 @@
+{
+  "lexicon": 1,
+  "id": "community.lexicon.forms.response",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record declaring a response to a form.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": [
+          "subject",
+          "answers"
+        ],
+        "properties": {
+          "subject": {
+            "type": "ref",
+            "ref": "community.lexicon.forms.form#main",
+            "description": "The form the response is to."
+          },
+          "answers": {
+            "type": "array",
+            "description": "The answers to the questions in the form.",
+            "items": {
+              "type": "ref",
+              "ref": "community.lexicon.forms.response#questionanswer"
+            }
+          }
+        }
+      }
+    },
+    "questionanswer": {
+      "type": "object",
+      "description": "An answer to a specific question in a form.",
+      "required": [
+          "subject",
+          "values"
+      ],
+      "properties": {
+        "subject": {
+          "type": "ref",
+          "ref": "community.lexicon.forms.question#main",
+          "description": "The question this answer is to."
+        },
+        "values": {
+          "type": "array",
+          "description": "The values of the response. For text or multiple choiced based question, length will be one.",
+          "items": {
+            "type": "string",
+            "maxLength": 5000
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This introduces the community.lexicon.form NSID.
Merge after 2025-02-??

# Design choices
## Structure
```mermaid
flowchart TD
    A[Form] -->|reference| B[Question]
    C[Response] -->|reference|A
    C[Response] -->|contains|D[Answer]
    D[Answer] --> |reference|B
```
## Choices
- Multiple choice questions support media in the case of a multiple choice image selection
- Required attribute on `question`, but no way to enforce on `response` through the lexicon

## Open Questions/Potential Problems
- In the `form` lexicon, should
```json
"questions": {
            "type": "array",
            "description": "The questions in the form.",
            "items": {
              "type": "ref",
              "ref": "com.atproto.repo.strongRef"
            }
          }
```
be a `community.lexicon.forms.question` or a `strongref`? I was thinking `strongref` so that if a question record is updated, the form and answer record don't need updates to their content. This introduces the possibility of a mismatch q/a type, which would be handled on an app view.
- Is it a problem that someone can go back and edit a response or a question? I think this is generally a protocol level issue that is handled in app views, similar to posts. Anyone can edit a Bluesky posting after people have quoted or liked it.
- Pros and cons of image content be a blob or URI? I did not have a preference toward either

# Examples
## Question
```json
{
  "title": "How satisfied are you with our service?",
  "description": "Please rate your level of satisfaction with our service on a scale of 1 to 5.",
  "questiontype": "community.lexicon.forms.question#multiplechoice",
  "questionoptions": [
    {
      "text": "1 - Very Unsatisfied"
    },
    {
      "text": "2 - Unsatisfied"
    },
    {
      "text": "3 - Neutral"
    },
    {
      "text": "4 - Satisfied"
    },
    {
      "text": "5 - Very Satisfied"
    }
  ],
  "required": true
}
```

## Form
```json
{
  "title": "Customer Feedback Survey",
  "createdAt": "2025-01-16T12:00:00Z",
  "description": "We would like your feedback on our services.",
  "questions": [
     {
       "cid": "bafyreibtzvf7y2p5n6vgthvysm64b6b6xx5iibzxjp76g6l32cfajrom3m",
       "uri": "at://did:plc:cbkjy5n7bk3ax2wplmtjofq2/community.lexicon.forms.question/3lergr2e6ig2z"
     }
  ]
}
```

## Response
```json
{
  "subject": {
     "cid": "bafyreibtzvf7y2p5n6vgthvysm64b6b6xx5iibzxjp76g6l32cfajrom3m",
     "uri": "at://did:plc:cbkjy5n7bk3ax2wplmtjofq2/community.lexicon.forms.form/8h9gergr2e6ig2z"
   },
  "createdAt": "2025-01-02T12:45:30.617Z",
  "answers": [
    {
      "subject": {
         "cid": "bafyreibtzvf7y2p5n6vgthvysm64b6b6xx5iibzxjp76g6l32cfajrom3m",
         "uri": "at://did:plc:cbkjy5n7bk3ax2wplmtjofq2/community.lexicon.forms.question/3lergr2e6ig2z"
      },
      "values": ["1 - Very Unsatisfied"]
    }
  ]
}
```

# Intended use
- Creating a form with different question formats (for now text, multiple choice, select many)
- Completing a form

# License and Assignment

- [x] I assign all rights of this contribution to Lexicon Community as an open source contribution under the MIT license.
