### PR TITLE
Add Recipe and Recipe Collection Lexicons

### DIFF
--- a/community/lexicon/recipes/README.md
+++ b/community/lexicon/recipes/README.md
@@ -1,0 +1,125 @@
+# community.lexicon.recipes
+
+A set of AT Protocol lexicons for sharing recipes
+
+## Examples
+
+### community.lexicon.recipes.recipe
+
+```json
+{
+  "$type": "community.lexicon.recipes.recipe",
+  "name": "Classic Chocolate Chip Cookies",
+  "text": "Soft and chewy chocolate chip cookies with crispy edges and a gooey center.",
+  "attribution": {
+    "type": "original",
+    "license": "community.lexicon.recipes.defs#licenseCreativeCommonsBy"
+  },
+  "ingredients": [
+    "2 1/4 cups (280g) all-purpose flour",
+    "1 tsp baking soda",
+    "1 tsp salt",
+    "1 cup (230g) unsalted butter, softened",
+    "3/4 cup (150g) granulated sugar",
+    "3/4 cup (165g) packed brown sugar",
+    "2 large eggs",
+    "2 tsp vanilla extract",
+    "2 cups (340g) semi-sweet chocolate chips",
+    "1 cup (170g) chopped walnuts (optional)"
+  ],
+  "instructions": [
+    "Preheat oven to 375°F (190°C). Line baking sheets with parchment paper.",
+    "In a medium bowl, whisk together flour, baking soda, and salt. Set aside.",
+    "In a large bowl, cream together softened butter, granulated sugar, and brown sugar until light and fluffy (about 3 minutes).",
+    "Beat in eggs one at a time, then stir in vanilla extract.",
+    "Gradually mix in the dry ingredients until just combined.",
+    "Fold in chocolate chips and walnuts if using.",
+    "Drop rounded tablespoons of dough onto prepared baking sheets, spacing cookies about 2 inches apart.",
+    "Bake for 9-11 minutes or until edges are lightly golden brown.",
+    "Let cool on baking sheets for 5 minutes before transferring to wire racks to cool completely."
+  ],
+  "embed": {
+    "images": [
+      {
+        "image": {
+          "$type": "blob",
+          "ref": {
+            "$link": "abcdefg123456"
+          },
+          "mimeType": "image/jpeg",
+          "size": 245000
+        },
+        "alt": "Stack of golden brown chocolate chip cookies on a wire cooling rack",
+        "aspectRatio": {
+          "width": 4,
+          "height": 3
+        }
+      },
+      {
+        "image": {
+          "$type": "blob",
+          "ref": {
+            "$link": "abcdefg123457"
+          },
+          "mimeType": "image/jpeg",
+          "size": 267000
+        },
+        "alt": "Cross section of a chocolate chip cookie showing melted chocolate chips and soft interior",
+        "aspectRatio": {
+          "width": 1,
+          "height": 1
+        }
+      }
+    ]
+  },
+  "prepTime": "PT20M",
+  "cookTime": "PT11M",
+  "totalTime": "PT45M",
+  "recipeYield": "24 cookies",
+  "recipeCategory": "community.lexicon.recipes.defs#categoryDessert",
+  "recipeCuisine": "community.lexicon.recipes.defs#cuisineAmerican",
+  "cookingMethod": "community.lexicon.recipes.defs#cookingMethodBaking",
+  "nutrition": {
+    "calories": 150,
+    "fatContent": 7.5,
+    "proteinContent": 2.0,
+    "carbohydrateContent": 20.0
+  },
+  "suitableForDiet": [
+    "community.lexicon.recipes.defs#dietVegetarian"
+  ],
+  "keywords": [
+    "cookies",
+    "chocolate",
+    "baking",
+    "dessert",
+    "snack",
+    "chocolate chip",
+    "classic"
+  ],
+  "createdAt": "2025-01-23T08:00:00.000Z",
+  "updatedAt": "2025-01-23T08:00:00.000Z"
+}
+```
+
+### community.lexicon.recipes.collection
+
+```json
+{
+  "$type": "community.lexicon.recipes.collection",
+  "name": "Annual Holiday Cookie Box",
+  "text": "The assortment of cookies I bake for friends and family each December.",
+  "recipes": [
+    {
+      "uri": "at://did:plc:1234/community.lexicon.recipes.recipe/01JEVQRA9MCR23263PARX101PE",
+      "cid": "01JEVQRA9MCR23263PARX101PE"
+    },
+    {
+      "uri": "at://did:plc:1234/community.lexicon.recipes.recipe/01JEVTAXQ4A79X03CBTE1NTTQZ",
+      "cid": "01JEVTAXQ4A79X03CBTE1NTTQZ"
+    }
+  ],
+  "createdAt": "2024-12-18T18:02:30Z",
+  "updatedAt": "2024-12-18T18:02:30Z"
+}
+```

--- a/community/lexicon/recipes/collection.json
+++ b/community/lexicon/recipes/collection.json
@@ -1,0 +1,40 @@
+{
+  "lexicon": 1,
+  "id": "community.lexicon.recipes.collection",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record for a collection of recipes.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["name", "createdAt", "updatedAt"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 100
+          },
+          "text": {
+            "type": "string",
+            "maxLength": 1000
+          },
+          "recipes": {
+            "type": "array",
+            "items": {
+              "type": "ref",
+              "ref": "com.atproto.repo.strongRef"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "datetime"
+          }
+        }
+      }
+    }
+  }
+}

--- a/community/lexicon/recipes/defs.json
+++ b/community/lexicon/recipes/defs.json
@@ -1,0 +1,343 @@
+{
+  "lexicon": 1,
+  "id": "community.lexicon.recipes.defs",
+  "description": "Shared definitions for the recipe Lexicon, including cooking methods, dietary restrictions, categories, cuisines, attribution types, publication types, and licenses.",
+  "defs": {
+    "attributionTypeOriginal": {
+      "type": "token",
+      "description": "Original recipe created by the author."
+    },
+    "attributionTypePerson": {
+      "type": "token",
+      "description": "Recipe shared by a specific person, such as family or friend."
+    },
+    "attributionTypePublication": {
+      "type": "token",
+      "description": "Recipe from a published source like a book or magazine."
+    },
+    "attributionTypeWebsite": {
+      "type": "token",
+      "description": "Recipe from a website or blog."
+    },
+    "attributionTypeShow": {
+      "type": "token",
+      "description": "Recipe from a TV show, streaming content, or video."
+    },
+    "attributionTypeProduct": {
+      "type": "token",
+      "description": "Recipe from a product package or label."
+    },
+    "categoryAppetizer": {
+      "type": "token",
+      "description": "A small dish served before a main meal."
+    },
+    "categoryBeverage": {
+      "type": "token",
+      "description": "Drinkable recipes including both alcoholic and non-alcoholic beverages."
+    },
+    "categoryBreakfast": {
+      "type": "token",
+      "description": "Dishes typically served in the morning."
+    },
+    "categoryBrunch": {
+      "type": "token",
+      "description": "Dishes suitable for late morning/early afternoon meals."
+    },
+    "categoryCocktail": {
+      "type": "token",
+      "description": "Alcoholic mixed drink recipes."
+    },
+    "categoryDessert": {
+      "type": "token",
+      "description": "Sweet dishes typically served after a main meal."
+    },
+    "categoryDinner": {
+      "type": "token",
+      "description": "Main dishes typically served in the evening."
+    },
+    "categoryEntree": {
+      "type": "token",
+      "description": "Main course dishes."
+    },
+    "categoryGarnish": {
+      "type": "token",
+      "description": "Decorative or flavorful additions to other dishes."
+    },
+    "categoryKidFriendly": {
+      "type": "token",
+      "description": "Recipes suitable for children."
+    },
+    "categoryLunch": {
+      "type": "token",
+      "description": "Dishes typically served midday."
+    },
+    "categorySalad": {
+      "type": "token",
+      "description": "Cold dishes primarily composed of mixed ingredients."
+    },
+    "categorySide": {
+      "type": "token",
+      "description": "Dishes meant to accompany main courses."
+    },
+    "categorySnack": {
+      "type": "token",
+      "description": "Small portions meant to be eaten between meals."
+    },
+    "categorySoup": {
+      "type": "token",
+      "description": "Liquid food served hot or cold."
+    },
+    "cookingMethodAirFrying": {
+      "type": "token",
+      "description": "Cooking food using hot air circulation in an air fryer."
+    },
+    "cookingMethodBaking": {
+      "type": "token",
+      "description": "Cooking food by exposing it to dry heat in an oven or similar environment."
+    },
+    "cookingMethodBroiling": {
+      "type": "token",
+      "description": "Cooking food directly under high heat."
+    },
+    "cookingMethodGrilling": {
+      "type": "token",
+      "description": "Cooking food on a grill or griddle with direct heat."
+    },
+    "cookingMethodFrying": {
+      "type": "token",
+      "description": "Cooking food in hot oil or fat."
+    },
+    "cookingMethodRoasting": {
+      "type": "token",
+      "description": "Cooking food by exposing it to dry heat with hot air circulating around it."
+    },
+    "cookingMethodSauteing": {
+      "type": "token",
+      "description": "Cooking food quickly in a small amount of fat over high heat."
+    },
+    "cookingMethodSteaming": {
+      "type": "token",
+      "description": "Cooking food using steam from boiling water."
+    },
+    "cookingMethodSlowCooking": {
+      "type": "token",
+      "description": "Cooking food at low temperatures for extended periods."
+    },
+    "cookingMethodPressureCooking": {
+      "type": "token",
+      "description": "Cooking food using pressure and steam in a sealed vessel."
+    },
+    "cookingMethodNoCook": {
+      "type": "token",
+      "description": "Recipe requires no cooking or heat application."
+    },
+    "cuisineAfrican": {
+      "type": "token",
+      "description": "Dishes from African culinary traditions."
+    },
+    "cuisineAmerican": {
+      "type": "token",
+      "description": "Dishes from United States culinary traditions."
+    },
+    "cuisineAustralian": {
+      "type": "token",
+      "description": "Dishes from Australian culinary traditions."
+    },
+    "cuisineBrazilian": {
+      "type": "token",
+      "description": "Dishes from Brazilian culinary traditions."
+    },
+    "cuisineBritish": {
+      "type": "token",
+      "description": "Dishes from British culinary traditions."
+    },
+    "cuisineCaribbean": {
+      "type": "token",
+      "description": "Dishes from Caribbean culinary traditions."
+    },
+    "cuisineChinese": {
+      "type": "token",
+      "description": "Dishes from Chinese culinary traditions."
+    },
+    "cuisineCreole": {
+      "type": "token",
+      "description": "Dishes from Creole culinary traditions."
+    },
+    "cuisineEuropean": {
+      "type": "token",
+      "description": "Dishes from European culinary traditions."
+    },
+    "cuisineFrench": {
+      "type": "token",
+      "description": "Dishes from French culinary traditions."
+    },
+    "cuisineGerman": {
+      "type": "token",
+      "description": "Dishes from German culinary traditions."
+    },
+    "cuisineGreek": {
+      "type": "token",
+      "description": "Dishes from Greek culinary traditions."
+    },
+    "cuisineIndian": {
+      "type": "token",
+      "description": "Dishes from Indian culinary traditions."
+    },
+    "cuisineIndonesian": {
+      "type": "token",
+      "description": "Dishes from Indonesian culinary traditions."
+    },
+    "cuisineItalian": {
+      "type": "token",
+      "description": "Dishes from Italian culinary traditions."
+    },
+    "cuisineJapanese": {
+      "type": "token",
+      "description": "Dishes from Japanese culinary traditions."
+    },
+    "cuisineKorean": {
+      "type": "token",
+      "description": "Dishes from Korean culinary traditions."
+    },
+    "cuisineLebanese": {
+      "type": "token",
+      "description": "Dishes from Lebanese culinary traditions."
+    },
+    "cuisineMediterranean": {
+      "type": "token",
+      "description": "Dishes from Mediterranean culinary traditions."
+    },
+    "cuisineMexican": {
+      "type": "token",
+      "description": "Dishes from Mexican culinary traditions."
+    },
+    "cuisineMiddleEastern": {
+      "type": "token",
+      "description": "Dishes from Middle Eastern culinary traditions."
+    },
+    "cuisineMoroccan": {
+      "type": "token",
+      "description": "Dishes from Moroccan culinary traditions."
+    },
+    "cuisinePeruvian": {
+      "type": "token",
+      "description": "Dishes from Peruvian culinary traditions."
+    },
+    "cuisinePolish": {
+      "type": "token",
+      "description": "Dishes from Polish culinary traditions."
+    },
+    "cuisinePortuguese": {
+      "type": "token",
+      "description": "Dishes from Portuguese culinary traditions."
+    },
+    "cuisineRussian": {
+      "type": "token",
+      "description": "Dishes from Russian culinary traditions."
+    },
+    "cuisineSpanish": {
+      "type": "token",
+      "description": "Dishes from Spanish culinary traditions."
+    },
+    "cuisineSouthern": {
+      "type": "token",
+      "description": "Dishes from Southern United States culinary traditions."
+    },
+    "cuisineTexan": {
+      "type": "token",
+      "description": "Dishes from Texan culinary traditions."
+    },
+    "cuisineTexMex": {
+      "type": "token",
+      "description": "Dishes combining Texan and Mexican culinary traditions."
+    },
+    "cuisineThai": {
+      "type": "token",
+      "description": "Dishes from Thai culinary traditions."
+    },
+    "cuisineTurkish": {
+      "type": "token",
+      "description": "Dishes from Turkish culinary traditions."
+    },
+    "cuisineVietnamese": {
+      "type": "token",
+      "description": "Dishes from Vietnamese culinary traditions."
+    },
+    "dietLowFat": {
+      "type": "token",
+      "description": "Recipe suitable for diets restricting fat intake."
+    },
+    "dietLowCalorie": {
+      "type": "token",
+      "description": "Recipe suitable for calorie-restricted diets."
+    },
+    "dietLowCarb": {
+      "type": "token",
+      "description": "Recipe suitable for diets restricting carbohydrate intake."
+    },
+    "dietVegetarian": {
+      "type": "token",
+      "description": "Recipe contains no meat or fish but may contain animal products like eggs and dairy."
+    },
+    "dietVegan": {
+      "type": "token",
+      "description": "Recipe contains no animal products whatsoever."
+    },
+    "dietGlutenFree": {
+      "type": "token",
+      "description": "Recipe contains no gluten-containing ingredients."
+    },
+    "dietDiabetic": {
+      "type": "token",
+      "description": "Recipe suitable for diabetic dietary requirements."
+    },
+    "dietHalal": {
+      "type": "token",
+      "description": "Recipe complies with Islamic dietary laws."
+    },
+    "dietKosher": {
+      "type": "token",
+      "description": "Recipe complies with Jewish dietary laws."
+    },
+    "dietPaleo": {
+      "type": "token",
+      "description": "Recipe suitable for paleolithic diet requirements."
+    },
+    "dietKeto": {
+      "type": "token",
+      "description": "Recipe suitable for ketogenic diet requirements."
+    },
+    "licenseAllRights": {
+      "type": "token",
+      "description": "All rights reserved by the creator."
+    },
+    "licenseCreativeCommonsBy": {
+      "type": "token",
+      "description": "Creative Commons Attribution 4.0 License."
+    },
+    "licenseCreativeCommonsBySa": {
+      "type": "token",
+      "description": "Creative Commons Attribution-ShareAlike 4.0 License."
+    },
+    "licenseCreativeCommonsByNc": {
+      "type": "token",
+      "description": "Creative Commons Attribution-NonCommercial 4.0 License."
+    },
+    "licenseCreativeCommonsByNcSa": {
+      "type": "token",
+      "description": "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 License."
+    },
+    "licensePublicDomain": {
+      "type": "token",
+      "description": "Work dedicated to the public domain."
+    },
+    "publicationTypeBook": {
+      "type": "token",
+      "description": "Recipe from a published book."
+    },
+    "publicationTypeMagazine": {
+      "type": "token",
+      "description": "Recipe from a magazine."
+    }
+  }
+}

--- a/community/lexicon/recipes/recipe.json
+++ b/community/lexicon/recipes/recipe.json
@@ -1,0 +1,277 @@
+{
+  "lexicon": 1,
+  "id": "community.lexicon.recipes.recipe",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record for a culinary recipe.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": [
+          "name",
+          "text",
+          "ingredients",
+          "instructions",
+          "createdAt",
+          "updatedAt"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "The name of the recipe"
+          },
+          "text": {
+            "type": "string",
+            "maxLength": 1000,
+            "description": "A description of the recipe"
+          },
+          "attribution": {
+            "type": "union",
+            "refs": [
+              "#originalAttribution",
+              "#personAttribution",
+              "#productAttribution",
+              "#publicationAttribution",
+              "#showAttribution",
+              "#websiteAttribution"
+            ]
+          },
+          "ingredients": {
+            "type": "array",
+            "description": "List of ingredients and their measurements",
+            "items": {
+              "type": "string",
+              "maxLength": 500
+            }
+          },
+          "instructions": {
+            "type": "array",
+            "description": "Step by step cooking instructions",
+            "items": {
+              "type": "string",
+              "maxLength": 1000
+            }
+          },
+          "embed": {
+            "type": "ref",
+            "ref": "#imagesEmbed"
+          },
+          "prepTime": {
+            "type": "string",
+            "format": "duration",
+            "description": "Time required for preparation"
+          },
+          "cookTime": {
+            "type": "string",
+            "format": "duration",
+            "description": "Time required for cooking"
+          },
+          "totalTime": {
+            "type": "string",
+            "format": "duration",
+            "description": "Total time required"
+          },
+          "recipeYield": {
+            "type": "string",
+            "description": "Number of servings or yield"
+          },
+          "recipeCategory": {
+            "type": "string",
+            "description": "Category of recipe (e.g., appetizer, main course)",
+            "knownValues": [
+              "community.lexicon.recipes.defs#recipeCategory"
+            ]
+          },
+          "recipeCuisine": {
+            "type": "string",
+            "description": "Cuisine type (e.g., Italian, Mexican)",
+            "knownValues": [
+              "community.lexicon.recipes.defs#recipeCuisine"
+            ]
+          },
+          "cookingMethod": {
+            "type": "string",
+            "description": "Method of cooking (e.g., baking, grilling)",
+            "knownValues": [
+              "community.lexicon.recipes.defs#cookingMethod"
+            ]
+          },
+          "nutrition": {
+            "type": "object",
+            "description": "Nutritional information",
+            "properties": {
+              "calories": { "type": "integer" },
+              "fatContent": { "type": "number" },
+              "proteinContent": { "type": "number" },
+              "carbohydrateContent": { "type": "number" }
+            }
+          },
+          "suitableForDiet": {
+            "type": "array",
+            "description": "Dietary restrictions this recipe is suitable for",
+            "items": {
+              "type": "string",
+              "knownValues": [
+                "community.lexicon.recipes.defs#diet"
+              ]
+            }
+          },
+          "keywords": {
+            "type": "array",
+            "description": "Tags describing the recipe",
+            "items": {
+              "type": "string",
+              "maxLength": 64
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Timestamp when this recipe was created"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Timestamp when this recipe was last updated"
+          }
+        }
+      }
+    },
+    "imagesEmbed": {
+      "type": "object",
+      "required": ["images"],
+      "properties": {
+        "images": {
+          "type": "array",
+          "items": { "type": "ref", "ref": "#image" },
+          "maxLength": 4
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": ["image", "alt"],
+      "properties": {
+        "image": {
+          "type": "blob",
+          "accept": ["image/*"],
+          "maxSize": 1000000
+        },
+        "alt": {
+          "type": "string",
+          "description": "Alt text description of the image, for accessibility."
+        },
+        "aspectRatio": {
+          "type": "ref",
+          "ref": "app.bsky.embed.defs#aspectRatio"
+        }
+      }
+    },
+    "view": {
+      "type": "object",
+      "required": ["images"],
+      "properties": {
+        "images": {
+          "type": "array",
+          "items": { "type": "ref", "ref": "#viewImage" },
+          "maxLength": 4
+        }
+      }
+    },
+    "viewImage": {
+      "type": "object",
+      "required": ["thumb", "fullsize", "alt"],
+      "properties": {
+        "thumb": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL for thumbnail version of the image."
+        },
+        "fullsize": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL for full size version of the image."
+        },
+        "alt": {
+          "type": "string",
+          "description": "Alt text description of the image, for accessibility."
+        },
+        "aspectRatio": {
+          "type": "ref",
+          "ref": "app.bsky.embed.defs#aspectRatio"
+        }
+      }
+    },
+    "originalAttribution": {
+      "type": "object",
+      "required": ["type", "license"],
+      "properties": {
+        "type": { "type": "ref", "ref": "community.lexicon.recipes.defs#attributionType", "const": "original" },
+        "license": { "type": "ref", "ref": "community.lexicon.recipes.defs#license" },
+        "url": { "type": "string", "format": "uri" }
+      }
+    },
+    "personAttribution": {
+      "type": "object",
+      "required": ["type", "name"],
+      "properties": {
+        "type": { "type": "ref", "ref": "community.lexicon.recipes.defs#attributionType", "const": "person" },
+        "name": { "type": "string", "maxLength": 255 },
+        "url": { "type": "string", "format": "uri" },
+        "notes": { "type": "string", "maxLength": 1000 }
+      }
+    },
+    "publicationAttribution": {
+      "type": "object",
+      "required": ["type", "publicationType", "title", "author"],
+      "properties": {
+        "type": { "type": "ref", "ref": "community.lexicon.recipes.defs#attributionType", "const": "publication" },
+        "publicationType": { "type": "ref", "ref": "community.lexicon.recipes.defs#publicationType" },
+        "title": { "type": "string", "maxLength": 255 },
+        "author": { "type": "string", "maxLength": 255 },
+        "publisher": { "type": "string", "maxLength": 255 },
+        "isbn": { "type": "string", "maxLength": 13 },
+        "page": { "type": "integer" },
+        "url": { "type": "string", "format": "uri" },
+        "notes": { "type": "string", "maxLength": 1000 }
+      }
+    },
+    "websiteAttribution": {
+      "type": "object",
+      "required": ["type", "name", "url"],
+      "properties": {
+        "type": { "type": "ref", "ref": "community.lexicon.recipes.defs#attributionType", "const": "website" },
+        "name": { "type": "string", "maxLength": 255 },
+        "url": { "type": "string", "format": "uri" },
+        "notes": { "type": "string", "maxLength": 1000 }
+      }
+    },
+    "showAttribution": {
+      "type": "object",
+      "required": ["type", "title", "network"],
+      "properties": {
+        "type": { "type": "ref", "ref": "community.lexicon.recipes.defs#attributionType", "const": "show" },
+        "title": { "type": "string", "maxLength": 255 },
+        "episode": { "type": "string", "maxLength": 255 },
+        "network": { "type": "string", "maxLength": 255 },
+        "airDate": { "type": "string", "format": "date" },
+        "url": { "type": "string", "format": "uri" },
+        "notes": { "type": "string", "maxLength": 1000 }
+      }
+    },
+    "productAttribution": {
+      "type": "object",
+      "required": ["type", "brand", "name"],
+      "properties": {
+        "type": { "type": "ref", "ref": "community.lexicon.recipes.defs#attributionType", "const": "product" },
+        "brand": { "type": "string", "maxLength": 255 },
+        "name": { "type": "string", "maxLength": 255 },
+        "upc": { "type": "string", "maxLength": 13 },
+        "url": { "type": "string", "format": "uri" },
+        "notes": { "type": "string", "maxLength": 1000 }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces two new lexicons for sharing recipes on the AT Protocol:

- `community.lexicon.recipes.recipe`: A schema for individual recipes
- `community.lexicon.recipes.collection`: A schema for organizing recipes into collections

A version of these lexicons is currently in production use at [recipe.exchange](https://recipe.exchange).

The recipe schema is heavily inspired by [Schema.org's Recipe type](https://schema.org/Recipe) with two notable distinctions:
1. Custom attribution properties to clearly denote recipe authorship and licensing
2. Multi-image support using the same pattern as `app.bsky.feed.post`

The recipe lexicon currently reuses `app.bsky.embed.defs#aspectRatio` for image handling. However, I suspect this may warrant redefinition within the community lexicon. I’m eager to hear others’ thoughts on this.

Examples of usage are provided in the README.

## License and Assignment

- [x] I assign all rights of this contribution to Lexicon Community as an open source contribution under the MIT license.