### PR TITLE
Add profile, phone number, and web link lexicons

### DIFF
--- a/community/lexicon/actor/README.md
+++ b/community/lexicon/actor/README.md
@@ -6,7 +6,7 @@ Identity and profile-related lexicons for the AT Protocol.
 
 ### community.lexicon.actor.profile
 
-This lexicon provides extended profile information. It adds structured data for contact information, location, and categorized links.
+This lexicon provides extended profile information. It adds structured data for contact information, location, and links.
 
 ```json
 {
@@ -14,7 +14,9 @@ This lexicon provides extended profile information. It adds structured data for 
   "displayName": "Downtown Coffee Co.",
   "description": "Artisanal coffee roasters and café in downtown Portland. Sourcing single-origin beans since 2015.",
   "email": "hello@downtowncoffee.com",
-  "phone": "+1-503-555-0123",
+  "phone": {
+    "number": "+15035550123"
+  },
   "address": {
     "name": "Downtown Coffee Co.",
     "street": "123 SW Park Ave",
@@ -25,17 +27,14 @@ This lexicon provides extended profile information. It adds structured data for 
   },
   "links": [
     {
-      "type": "website",
-      "url": "https://downtowncoffee.com"
+      "url": "https://downtowncoffee.com",
+      "title": "Official Website",
+      "description": "Visit our website for our full menu, locations, and online ordering"
     },
     {
-      "type": "instagram",
-      "url": "https://instagram.com/downtowncoffee"
-    },
-    {
-      "type": "menu",
-      "url": "https://downtowncoffee.com/menu",
-      "title": "View Our Menu"
+      "url": "https://instagram.com/downtowncoffee",
+      "title": "Follow us on Instagram",
+      "description": "Daily coffee photos and café updates"
     }
   ],
   "createdAt": "2025-01-28T15:32:20.417Z"

--- a/community/lexicon/actor/README.md
+++ b/community/lexicon/actor/README.md
@@ -1,0 +1,43 @@
+# community.lexicon.actor
+
+Identity and profile-related lexicons for the AT Protocol.
+
+## Examples
+
+### community.lexicon.actor.profile
+
+This lexicon provides extended profile information. It adds structured data for contact information, location, and categorized links.
+
+```json
+{
+  "$type": "community.lexicon.actor.profile",
+  "displayName": "Downtown Coffee Co.",
+  "description": "Artisanal coffee roasters and café in downtown Portland. Sourcing single-origin beans since 2015.",
+  "email": "hello@downtowncoffee.com",
+  "phone": "+1-503-555-0123",
+  "address": {
+    "name": "Downtown Coffee Co.",
+    "street": "123 SW Park Ave",
+    "locality": "Portland",
+    "region": "OR",
+    "postalCode": "97204",
+    "country": "US"
+  },
+  "links": [
+    {
+      "type": "website",
+      "url": "https://downtowncoffee.com"
+    },
+    {
+      "type": "instagram",
+      "url": "https://instagram.com/downtowncoffee"
+    },
+    {
+      "type": "menu",
+      "url": "https://downtowncoffee.com/menu",
+      "title": "View Our Menu"
+    }
+  ],
+  "createdAt": "2025-01-28T15:32:20.417Z"
+}
+```

--- a/community/lexicon/actor/profile.json
+++ b/community/lexicon/actor/profile.json
@@ -1,0 +1,97 @@
+{
+  "lexicon": 1,
+  "id": "community.lexicon.actor.profile",
+  "description": "Extended profile information for AT Protocol actors",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "An extended profile record.",
+      "key": "literal:self",
+      "record": {
+        "type": "object",
+        "required": [
+          "displayName",
+          "createdAt"
+        ],
+        "properties": {
+          "displayName": {
+            "type": "string",
+            "maxGraphemes": 64,
+            "maxLength": 640
+          },
+          "description": {
+            "type": "string",
+            "description": "Free-form profile description text.",
+            "maxGraphemes": 256,
+            "maxLength": 2560
+          },
+          "avatar": {
+            "type": "blob",
+            "description": "Profile image",
+            "accept": [
+              "image/png",
+              "image/jpeg"
+            ],
+            "maxSize": 1000000
+          },
+          "banner": {
+            "type": "blob",
+            "description": "Banner image",
+            "accept": [
+              "image/png",
+              "image/jpeg"
+            ],
+            "maxSize": 1000000
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "maxLength": 255
+          },
+          "phone": {
+            "type": "string",
+            "maxLength": 20,
+            "description": "International format phone number"
+          },
+          "address": {
+            "type": "ref",
+            "ref": "community.lexicon.locations.address"
+          },
+          "links": {
+            "type": "array",
+            "description": "Collection of related links for the profile",
+            "items": {
+              "type": "object",
+              "required": [
+                "url",
+                "type"
+              ],
+              "properties": {
+                "url": {
+                  "type": "string",
+                  "format": "uri",
+                  "maxLength": 2048
+                },
+                "type": {
+                  "type": "string",
+                  "description": "The type of link (e.g., website, twitter, instagram)",
+                  "maxLength": 50
+                },
+                "title": {
+                  "type": "string",
+                  "description": "Optional display title for the link",
+                  "maxLength": 100
+                }
+              }
+            },
+            "maxLength": 10
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime"
+          }
+        }
+      }
+    }
+  }
+}

--- a/community/lexicon/actor/profile.json
+++ b/community/lexicon/actor/profile.json
@@ -49,9 +49,8 @@
             "maxLength": 255
           },
           "phone": {
-            "type": "string",
-            "maxLength": 20,
-            "description": "International format phone number"
+            "type": "ref",
+            "ref": "community.lexicon.contact.phone"
           },
           "address": {
             "type": "ref",
@@ -61,28 +60,8 @@
             "type": "array",
             "description": "Collection of related links for the profile",
             "items": {
-              "type": "object",
-              "required": [
-                "url",
-                "type"
-              ],
-              "properties": {
-                "url": {
-                  "type": "string",
-                  "format": "uri",
-                  "maxLength": 2048
-                },
-                "type": {
-                  "type": "string",
-                  "description": "The type of link (e.g., website, twitter, instagram)",
-                  "maxLength": 50
-                },
-                "title": {
-                  "type": "string",
-                  "description": "Optional display title for the link",
-                  "maxLength": 100
-                }
-              }
+              "type": "ref",
+              "ref": "community.lexicon.web.link"
             },
             "maxLength": 10
           },

--- a/community/lexicon/contact/README.md
+++ b/community/lexicon/contact/README.md
@@ -1,0 +1,21 @@
+# Phone Number Lexicon
+
+This lexicon provides a standardized way to represent phone numbers in AT Protocol applications.
+
+## Features
+
+- E.164 format validation for international phone numbers
+- Phone number type categorization (mobile, home, work, etc.)
+- Country code support using ISO 3166-1 alpha-2 codes
+- Custom labeling support
+
+## Example Usage
+
+```json
+{
+  "number": "+14155552671",
+  "type": "mobile",
+  "label": "Personal Cell",
+  "countryCode": "US"
+}
+```

--- a/community/lexicon/contact/phone.json
+++ b/community/lexicon/contact/phone.json
@@ -1,0 +1,36 @@
+{
+  "lexicon": 1,
+  "id": "community.lexicon.contact.phone",
+  "description": "A lexicon for standardized phone number handling",
+  "defs": {
+    "main": {
+      "type": "object",
+      "description": "A phone number with standardized formatting and metadata",
+      "required": ["number"],
+      "properties": {
+        "number": {
+          "type": "string",
+          "description": "The phone number in E.164 format (e.g., +14155552671)",
+          "maxLength": 15,
+          "pattern": "^\\+[1-9]\\d{1,14}$"
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of phone number",
+          "enum": ["mobile", "home", "work", "fax", "other"]
+        },
+        "label": {
+          "type": "string",
+          "description": "Optional custom label for the phone number",
+          "maxLength": 50
+        },
+        "countryCode": {
+          "type": "string",
+          "description": "ISO 3166-1 alpha-2 country code for the phone number",
+          "pattern": "^[A-Z]{2}$",
+          "maxLength": 2
+        }
+      }
+    }
+  }
+}

--- a/community/lexicon/web/README.md
+++ b/community/lexicon/web/README.md
@@ -1,0 +1,27 @@
+# Web Link Lexicon
+
+This lexicon provides a standardized way to represent web links in AT Protocol applications. It provides a simple but flexible structure for URLs with optional descriptive metadata.
+
+## Features
+
+- Standardized URL handling with length constraints
+- Optional title and description fields
+- Reusable across different contexts (profiles, posts, etc.)
+
+## Example Usage
+
+Basic link:
+```json
+{
+  "url": "https://example.com"
+}
+```
+
+Link with metadata:
+```json
+{
+  "url": "https://example.com",
+  "title": "Example Website",
+  "description": "A comprehensive example of web linking"
+}
+```

--- a/community/lexicon/web/link.json
+++ b/community/lexicon/web/link.json
@@ -1,0 +1,30 @@
+{
+  "lexicon": 1,
+  "id": "community.lexicon.web.link",
+  "description": "A lexicon for standardized web link handling and categorization",
+  "defs": {
+    "main": {
+      "type": "object",
+      "description": "A web link with metadata and categorization",
+      "required": ["url"],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "The URL of the link",
+          "maxLength": 2048
+        },
+        "title": {
+          "type": "string",
+          "description": "Display title for the link",
+          "maxLength": 100
+        },
+        "description": {
+          "type": "string",
+          "description": "Optional description of the link",
+          "maxLength": 500
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a set of new community lexicons that provide extended profile and contact information capabilities for AT Protocol actors:

1. community.lexicon.actor.profile - Core profile lexicon. This is similar to the existing `app.bsky.actor.profile` lexicon but adds structured data for contact information and links.
2. community.lexicon.contact.phone - Standardized phone number handling with E.164 formatting and metadata
3. community.lexicon.web.link - Structured web link handling with metadata and categorization

Key features:

* Enhanced profile information through community.lexicon.actor.profile:
  - Basic profile fields (display name, description, avatar, banner)
  - Structured email contact information
  - Integration with phone and address lexicons
  - Support for profile links

* Standardized phone number handling via community.lexicon.contact.phone:
  - E.164 format validation
  - Phone number type categorization (mobile, home, work, etc.)
  - Optional labeling and country code support

* Rich link management through community.lexicon.web.link:
  - URL validation
  - Structured metadata (title, description)
  - Flexible usage for various link types

Example usage can be found in the README.

This collection of lexicons enables applications to store and display structured profile information independent of your Bluesky profile, with proper separation of concerns between profile data, contact information, and web resources.

## License and Assignment

- [x] I assign all rights of this contribution to Lexicon Community as an open source contribution under the MIT license.