### PR TITLE
Replacing community.lexicon.location.h3 with community.lexicon.location.hthree

### DIFF
--- a/community/lexicon/calendar/event.json
+++ b/community/lexicon/calendar/event.json
@@ -56,7 +56,7 @@
                                 "community.lexicon.location.address",
                                 "community.lexicon.location.fsq",
                                 "community.lexicon.location.geo",
-                                "community.lexicon.location.h3"
+                                "community.lexicon.location.hthree"
                             ]
                         }
                     },

--- a/community/lexicon/location/hthree.json
+++ b/community/lexicon/location/hthree.json
@@ -1,6 +1,6 @@
 {
     "lexicon": 1,
-    "id": "community.lexicon.location.h3",
+    "id": "community.lexicon.location.hthree",
     "defs": {
         "main": {
             "type": "object",


### PR DESCRIPTION
This renames the `community.lexicon.location.h3` type to `community.lexicon.location.hthree` to conform to the spec.

Although this is not technically a backwards compatible change, I think that because there aren't any records using it at the moment and also because this change is preventing the lexicon from being discovered, it is a safe thing to change in this way.

Alternatively, there could be an appetite to adjust the spec to support this format, but I think that it would take longer to adopt.