### PR TITLE
Run lex-cli on push to identify lexicon errors

### DIFF
--- a/.github/workflows/lex-cli.yml
+++ b/.github/workflows/lex-cli.yml
@@ -26,5 +26,5 @@ jobs:
         run: |
           lex gen-api --yes tmp ./community/lexicon/*/*.json > >(tee -a lex-gen-api-stdout.txt) 2> >(tee -a lex-gen-api-stderr.txt >&2)
           if [ -s "lex-gen-api-stderr.txt" ]; then
-            echo "::error"
+            exit 1
           fi

--- a/.github/workflows/lex-cli.yml
+++ b/.github/workflows/lex-cli.yml
@@ -1,0 +1,30 @@
+name: Run lex-cli
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  run-lex-cli:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install lex-cli
+        run: npm install -g @atproto/lex-cli
+
+      - name: Generate API from lexicon schemas
+        run: |
+          lex gen-api --yes tmp /usr/src/app/community/lexicon/*/*.json > >(tee -a lex-gen-api-stdout.txt) 2> >(tee -a lex-gen-api-stderr.txt >&2)
+          if [ -s "lex-gen-api-stderr.txt" ]; then
+            echo "::error"
+          fi

--- a/.github/workflows/lex-cli.yml
+++ b/.github/workflows/lex-cli.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Generate API from lexicon schemas
         run: |
-          lex gen-api --yes tmp /usr/src/app/community/lexicon/*/*.json > >(tee -a lex-gen-api-stdout.txt) 2> >(tee -a lex-gen-api-stderr.txt >&2)
+          lex gen-api --yes tmp ./community/lexicon/*/*.json > >(tee -a lex-gen-api-stdout.txt) 2> >(tee -a lex-gen-api-stderr.txt >&2)
           if [ -s "lex-gen-api-stderr.txt" ]; then
             echo "::error"
           fi

--- a/community/lexicon/location/hthree.json
+++ b/community/lexicon/location/hthree.json
@@ -3,7 +3,7 @@
     "id": "community.lexicon.location.hthree",
     "defs": {
         "main": {
-            "type": "object",
+            "type": "smobject",
             "description": "A physical location in the form of a H3 encoded location.",
             "required": [
                 "value"

--- a/community/lexicon/location/hthree.json
+++ b/community/lexicon/location/hthree.json
@@ -3,7 +3,7 @@
     "id": "community.lexicon.location.hthree",
     "defs": {
         "main": {
-            "type": "smobject",
+            "type": "object",
             "description": "A physical location in the form of a H3 encoded location.",
             "required": [
                 "value"


### PR DESCRIPTION
This PR introduces a GHA that runs the lex-cli on push and PR. If error output is produced, the action fails.

Example lexicon validation failure

![Screenshot 2025-03-01 at 10 28 49 AM](https://github.com/user-attachments/assets/1dfa0442-e504-4c88-878a-36d86922a8a8)

Example success / recovery

![Screenshot 2025-03-01 at 10 29 04 AM](https://github.com/user-attachments/assets/7c44f5d7-fd32-4ad4-8fd8-a6dc2588701c)
