### PR TITLE
Proposal: Lexicon schema resolution lexicon

### DIFF
--- a/community/lexicon/schema/defs.json
+++ b/community/lexicon/schema/defs.json
@@ -1,0 +1,20 @@
+{
+  "lexicon": 1,
+  "id": "community.lexicon.schema.defs",
+  "defs": {
+    "schemaView": {
+      "type": "object",
+      "required": ["uri", "cid", "record", "indexedAt", "dependencies"],
+      "properties": {
+        "uri": { "type": "string", "format": "at-uri" },
+        "cid": { "type": "string", "format": "cid" },
+        "record": { "type": "unknown" },
+        "indexedAt": { "type": "string", "format": "datetime" },
+        "dependencies": {
+          "type": "array",
+          "items": { "type": "ref", "ref": "com.atproto.repo.strongRef" }
+        }
+      }
+    }
+  }
+}

--- a/community/lexicon/schema/defs.json
+++ b/community/lexicon/schema/defs.json
@@ -12,6 +12,7 @@
         "indexedAt": { "type": "string", "format": "datetime" },
         "dependencies": {
           "type": "array",
+          "description": "List of direct dependencies of this schema. These are the external refs used within the record.",
           "items": { "type": "ref", "ref": "com.atproto.repo.strongRef" }
         }
       }

--- a/community/lexicon/schema/getSchemas.json
+++ b/community/lexicon/schema/getSchemas.json
@@ -1,0 +1,48 @@
+{
+  "lexicon": 1,
+  "id": "community.lexicon.schema.getSchemas",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Gets schema views for a specified list of lexicon schemas (by AT-URI, with optional CID).",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["refs"],
+          "properties": {
+            "refs": {
+              "type": "array",
+              "description": "List of schema refs (AT-URI with optional CID) to return hydrated views for.",
+              "items": {
+                "type": "object",
+                "required": ["uri"],
+                "properties": {
+                  "uri": { "type": "string", "format": "at-uri" },
+                  "cid": { "type": "string", "format": "cid" }
+                }
+              },
+              "maxLength": 25
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["schemas"],
+          "properties": {
+            "schemas": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "community.lexicon.schema.defs#schemaView"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This lexicon is based off of the discussion in https://github.com/orgs/lexicon-community/discussions/42 and my experience with building [lpm](https://github.com/tom-sherman/lpm).

This lexicon (just a single procedure right now) defines an interface for an appview that would be used in lpm to form a package manager for lexicons. The goal is for it to be generic though so it could drive other package managers, registries, or schema-related tooling. (This also justifies me adding it to community.lexicon and not some lpm NSID 😅)

The AppView fills the problem space described in the [lexicon resolution RFC](https://github.com/bluesky-social/atproto/discussions/3074):

> For services which do dynamic resolution and validation, we think that making requests to aggregation/index services could be a better option instead of doing live resolution. Such services can act as CDNs, archives, and mediating services to resolve disputes or security issues in Lexicons.

# License and Assignment

- [x] I assign all rights of this contribution to Lexicon Community as an open source contribution under the MIT license.
