### PR TITLE
Add a lexicon for referencing Google Place IDs.

### DIFF
--- a/community/lexicon/location/google.json
+++ b/community/lexicon/location/google.json
@@ -1,0 +1,23 @@
+{
+    "lexicon": 1,
+    "id": "community.lexicon.location.google",
+    "defs": {
+        "main": {
+            "type": "object",
+            "description": "A place identified by a Google Maps Place ID.",
+            "required": [
+                "place_id"
+            ],
+            "properties": {
+                "place_id": {
+                    "type": "string",
+                    "description": "The unique identifier of a place in the Google Places database and on Google Maps."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "A user-supplied name of the location. (Optional, as a name can be displayed using a Place ID)."
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is very similar to the Foursquare lexicon, providing a common record for Place IDs coming from Google's ecosystem.

I've intentionally excluded `latitude` and `longitude` as those fields can typically only be cached for [~30 days](https://cloud.google.com/maps-platform/terms/maps-service-terms?hl=en#:~:text=Customer%20may%20temporarily%20cache%20latitude%20and%20longitude%20values%20from%20the%20Places%20API%20for%20up%20to%2030%20consecutive%20calendar%20days%2C%20after%20which%20Customer%20must%20delete%20the%20cached%20latitude%20and%20longitude%20values.) which is difficult to achieve with current ATProto infrastructure.