### PR TITLE
Add Nominatim Location Lexicon

### DIFF
--- a/community/lexicon/location/nominatim.json
+++ b/community/lexicon/location/nominatim.json
@@ -1,0 +1,41 @@
+{
+    "lexicon": 1,
+    "id": "community.lexicon.location.nominatim",
+    "defs": {
+        "main": {
+            "type": "object",
+            "description": "A physical location from OpenStreetMap data via the Nominatim geocoding service.",
+            "required": [
+                "osm_id",
+                "osm_type"
+            ],
+            "properties": {
+                "osm_id": {
+                    "type": "string",
+                    "description": "The OpenStreetMap identifier for this location."
+                },
+                "osm_type": {
+                    "type": "string",
+                    "description": "The type of OpenStreetMap object.",
+                    "enum": ["node", "way", "relation"]
+                },
+                "latitude": {
+                    "type": "string",
+                    "description": "Latitude coordinate of the location."
+                },
+                "longitude": {
+                    "type": "string",
+                    "description": "Longitude coordinate of the location."
+                },
+                "display_name": {
+                    "type": "string",
+                    "description": "Human-readable address or location description."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the location."
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a new location lexicon for the Nominatim geocoding service, enabling ATProto applications to reference locations from OpenStreetMap data.

What is Nominatim?
Nominatim is the geocoding service powering OpenStreetMap's search functionality. It provides comprehensive location data including addresses, points of interest, and administrative boundaries from the collaborative OpenStreetMap database.

Lexicon Design
The lexicon follows the established community pattern while adapting to Nominatim's data model:

- Required identifiers: Uses **osm_id** and **osm_type** for stable, permanent location references
- Core location data: Includes coordinates, display name, and location name
- Simplified structure: Focuses on essential fields for a v1 implementation

Benefits

- Open data: Built on OpenStreetMap's freely available, community-maintained dataset
- Global coverage: Comprehensive worldwide location database
- Stable references: OSM IDs provide permanent identifiers that don't change over time
- Extensible: Simple foundation that can be expanded with additional Nominatim fields in future versions

Example Usage

```
json{
  "osm_id": "1234567",
  "osm_type": "node",
  "latitude": "45.4215",
  "longitude": "-75.6972",
  "display_name": "Parliament Hill, Ottawa, Ontario, Canada",
  "name": "Parliament Hill"
}
```

This lexicon complements the existing Foursquare location lexicon by providing an open-source alternative for location referencing in the ATProto ecosystem.