### PR TITLE
Add GeoJSON and Well-Known Text formats for complex location geometries

### DIFF
--- a/community/lexicon/location/bbox.json
+++ b/community/lexicon/location/bbox.json
@@ -1,0 +1,38 @@
+{
+    "lexicon": 1,
+    "id": "community.lexicon.location.bbox",
+    "defs": {
+        "main": {
+            "type": "object",
+            "description": "A bounding box representing a rectangular geographic area defined by its corner coordinates.",
+            "required": [
+                "north",
+                "west",
+                "south",
+                "east"
+            ],
+            "properties": {
+                "north": {
+                    "type": "string",
+                    "description": "The northern latitude boundary of the bounding box."
+                },
+                "west": {
+                    "type": "string",
+                    "description": "The western longitude boundary of the bounding box."
+                },
+                "south": {
+                    "type": "string",
+                    "description": "The southern latitude boundary of the bounding box."
+                },
+                "east": {
+                    "type": "string",
+                    "description": "The eastern longitude boundary of the bounding box."
+                }
+,                "name": {
+                    "type": "string",
+                    "description": "The name of the bounding box, if any."
+                }
+            }
+        }
+    }
+}

--- a/community/lexicon/location/geojson.json
+++ b/community/lexicon/location/geojson.json
@@ -1,0 +1,23 @@
+{
+    "lexicon": 1,
+    "id": "community.lexicon.location.geojson",
+    "defs": {
+        "main": {
+            "type": "object",
+            "description": "A geographic location represented as a GeoJSON geometry object (https://geojson.org/).",
+            "required": [
+                "geometry"
+            ],
+            "properties": {
+                "geometry": {
+                    "type": "bytes",
+                    "description": "The GeoJSON representation of the geometry, stored as a byte array."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the location, if any."
+                }
+            }
+        }
+    }
+}

--- a/community/lexicon/location/wkt.json
+++ b/community/lexicon/location/wkt.json
@@ -1,0 +1,23 @@
+{
+    "lexicon": 1,
+    "id": "community.lexicon.location.wkt",
+    "defs": {
+        "main": {
+            "type": "object",
+            "description": "A geographic location represented as a WKT (Well-Known Text) geometry object.",
+            "required": [
+                "geometry"
+            ],
+            "properties": {
+                "geometry": {
+                    "type": "string",
+                    "description": "The WKT representation of the geometry."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the location, if any."
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The current set of location schemas only support either point geometries, or grid cells using the H3 system.

This PR hopes to open up the ATGeo lexicon to representing all forms of spatial geometry, including lines, polygons, and geometry collections.

The two most-widely readable formats for flexible geospatial representation are [GeoJSON](https://geojson.org) and [Well-Known Text](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry), or WKT.

The proposed format for `community.lexicon.geo.geojson.geometry` is `bytes`, and not `object`, because GeoJSON data typically contains raw floating point values. The GeoJSON object could be represented as a string in Lexicon, but it might get confusing to developers or tools to have JSON embedded within JSON. That leaves `bytes` encoding as the obvious alternative, but maybe JSON-in-JSON isn't as bad as it seems?

The proposed format for `community.lexicon.geo.wkt.geometry` is just `string`, because WKT strings are meant, at some level, to be human readable.

The advantage of providing potential support for these two formats is that, as standard GIS interchange formats, we are leveraging prior art in representing multidimensional geometries and creating opportunity for interoperability with GIS software.

Finally, this PR includes a proposal for a bounding box geometry, which might be useful in the future for indicating rough geographic extents, or as part of a query schema. I have proposed `north, south, east, west` members in preference to `xmin, ymin, xmax, ymax` because longitude is always x and latitude always y. The inversion from conventional "lat/long" is a constant source of confusion to new geospatial developers and should be avoided.

All three proposed schemas include an optional `name` field for congruence with existing `community.lexicon.location` schemas.
