### PR TITLE
calendar.event: add rsvpExpected property

### DIFF
--- a/community/lexicon/calendar/event.json
+++ b/community/lexicon/calendar/event.json
@@ -68,7 +68,7 @@
                             "ref": "community.lexicon.calendar.event#uri"
                         }
                     },
-                    "rsvp": {
+                    "rsvpExpected": {
                         "type": "boolean",
                         "description": "Whether a response is requested from attendees."
                     }

--- a/community/lexicon/calendar/event.json
+++ b/community/lexicon/calendar/event.json
@@ -67,6 +67,10 @@
                             "type": "ref",
                             "ref": "community.lexicon.calendar.event#uri"
                         }
+                    },
+                    "rsvp": {
+                        "type": "boolean",
+                        "description": "Whether a response is requested from attendees."
                     }
                 }
             }


### PR DESCRIPTION
This is an optional field to indicate whether or not an RSVP is requested; this allows for an `event` to either act as a waypoint for a separate record (like calendar.city aims to do) or indicate an event that one can RSVP to.

This mirrors RFC 5545's "RSVP Expectation" parameter ([3.2.17](https://datatracker.ietf.org/doc/html/rfc5545#section-3.2.17)).

With this parameter, services like smokesignal.events could ingest calendar.city-published events without displaying an RSVP button.