### PR TITLE
Add permission sets for bookmarks

### DIFF
--- a/community/lexicon/bookmarks/authManageBookmarks.json
+++ b/community/lexicon/bookmarks/authManageBookmarks.json
@@ -1,0 +1,41 @@
+{
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1,
+  "id": "community.lexicon.bookmarks.authManageBookmarks",
+  "defs": {
+    "main": {
+      "type": "permission-set",
+      "title": "Manage bookmarks",
+      "title:lang": {
+        "ja": "ブックマークの管理",
+        "es": "Gestionar marcadores",
+        "pt": "Gerenciar favoritos",
+        "de": "Lesezeichen verwalten"
+      },
+      "detail": "View, create, edit, and delete the account's saved bookmarks.",
+      "detail:lang": {
+        "ja": "アカウントに保存されたブックマークの表示、作成、編集、削除を行います。",
+        "pt": "Ver, criar, editar e excluir os favoritos salvos da conta.",
+        "es": "Ver, crear, editar y eliminar los marcadores guardados de la cuenta.",
+        "de": "Die gespeicherten Lesezeichen des Kontos anzeigen, erstellen, bearbeiten und löschen."
+      },
+      "permissions": [
+        {
+          "type": "permission",
+          "resource": "rpc",
+          "inheritAud": true,
+          "lxm": [
+            "community.lexicon.bookmarks.getActorBookmarks"
+          ]
+        },
+        {
+          "type": "permission",
+          "resource": "repo",
+          "collection": [
+            "community.lexicon.bookmarks.bookmark"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/community/lexicon/bookmarks/authViewBookmarks.json
+++ b/community/lexicon/bookmarks/authViewBookmarks.json
@@ -1,0 +1,34 @@
+{
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1,
+  "id": "community.lexicon.bookmarks.authViewBookmarks",
+  "defs": {
+    "main": {
+      "type": "permission-set",
+      "title": "View bookmarks",
+      "title:lang": {
+        "ja": "ブックマークの表示",
+        "pt": "Ver favoritos",
+        "es": "Ver marcadores",
+        "de": "Lesezeichen anzeigen"
+      },
+      "detail": "View the account's saved bookmarks.",
+      "detail:lang": {
+        "ja": "アカウントに保存されたブックマークを表示します。",
+        "pt": "Ver os favoritos salvos da conta.",
+        "es": "Ver los marcadores guardados de la cuenta.",
+        "de": "Die gespeicherten Lesezeichen des Kontos anzeigen."
+      },
+      "permissions": [
+        {
+          "type": "permission",
+          "resource": "rpc",
+          "inheritAud": true,
+          "lxm": [
+            "community.lexicon.bookmarks.getActorBookmarks"
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Based on [this proposal](https://discourse.atprotocol.community/t/permission-sets-for-community-lexicon-bookmarks/764), this PR adds two permission sets for the bookmarks lexicon. Note that I added machine translation for the titles/descriptions for [the top 5 languages in the Bluesky lexicon](https://bsky.app/profile/mackuba.eu/post/3mhqjanm4i222). I do not speak any of these languages, so we should verify these if we want them.